### PR TITLE
Added CSRF token to contact form.

### DIFF
--- a/flask_wtforms_tutorial/templates/contact.jinja2
+++ b/flask_wtforms_tutorial/templates/contact.jinja2
@@ -8,6 +8,7 @@
 <div class="formwrapper">
   <h2 class="title">Contact</h2>
   <form method="POST" action="/">
+    {{ form.csrf_token }}
     <div class="form-field">{{ form.name.label }} {{ form.name(size=20) }}
       {% if form.name.errors %}
         <ul class="errors">


### PR DESCRIPTION
Hi Todd,

I think the contact form needs a CSRF token added. - The signup page has one, but this appears to be missing one.

